### PR TITLE
Add diode requirement, build guide, firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To build and use a Swoop MX you will need:
 * 34-36× Kailh hotswap sockets
 * 34-36× SK6812 Mini-E RGB SMD Leds (optional; not recommended for wireless)
 * 34-36× keycaps
+* 36× diodes (Surface-mount or Through-hole)
 * 2× Rotary encoders & knobs (optional; ALPS EC11)
 * 2× OLED LCD Display 128x32 SSD1306 (optional)
 * 2× reset switches (optional; B3U-1000P(M))
@@ -52,3 +53,14 @@ To build and use a Swoop MX you will need:
 * 16× M2 Screws (3mm thread length)  
 * 10× M2 Standoff for the plates (7mm)
 * 6× M2 Standoff for the controller cover (8mm)
+
+### How to build it
+
+<a href="https://youtu.be/pvvNYPsMyz4" target="_blank">
+  <img src="https://gist.githubusercontent.com/duckyb/337340baa1f0c8bcc06fef7b3b57242b/raw/97e6e0748dd1b8a3fb54fac0a88e84e6b6e0e10a/build-guide-button.svg" height="44">
+</a>
+
+### Firmware
+
+The firmware is available in QMK as `bluebell/swoop`.  
+You can get started by using QMK's [online configurator](https://config.qmk.fm/#/bluebell/swoop/LAYOUT_split_3x5_3). Or check the [Swoop README file](https://github.com/qmk/qmk_firmware/blob/master/keyboards/bluebell/swoop/readme.md) to see how to compile the firmware locally.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To build and use a Swoop MX you will need:
 
 **For the case:**
 
-* 16× M2 Screws (3mm thread length)  
+* 32× M2 Screws (3mm thread length)  
 * 10× M2 Standoff for the plates (7mm)
 * 6× M2 Standoff for the controller cover (8mm)
 


### PR DESCRIPTION
Diodes were missing from the list of required components.

I also added the link to the build guide and QMK firmware instructions.